### PR TITLE
support bf16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 datasets
 torch
-transformers>=4.44
+transformers>=4.45
 safetensors
 psutil
 accelerate

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ def build_cuda_extensions():
         delimiter = ' ' if ';' not in TORCH_CUDA_ARCH_LIST else ' '
         TORCH_CUDA_ARCH_LIST = TORCH_CUDA_ARCH_LIST.split(delimiter)
         compute_capabilities = [int(10 * float(arch)) for arch in TORCH_CUDA_ARCH_LIST if '+' not in arch]
+
+    print(" build for compute capabilities: ==============", compute_capabilities)
     for cap in compute_capabilities:
         arch_flags += ["-gencode", f"arch=compute_{cap},code=sm_{cap}"]
     extra_compile_args = {

--- a/vptq/__init__.py
+++ b/vptq/__init__.py
@@ -3,5 +3,5 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.2"
+__version__ = "0.0.2.post1"
 from .layers import AutoModelForCausalLM as AutoModelForCausalLM


### PR DESCRIPTION
Gracefully support bf16 for all nvidia-GPUs.
 For thoce old GPU like V100/T4, we just do the simulation and the computation actually happens  in float32.
This would be slower than half then.