### PR TITLE
Adds nvembed model to quantization algorithm

### DIFF
--- a/run_vptq.py
+++ b/run_vptq.py
@@ -119,6 +119,7 @@ if __name__ == "__main__":
 
     model.eval()
 
+    # TODO: add evaluation for SentenceTransformer (MTEB or other)
     if isinstance(model, SentenceTransformer):
         sentence1 = ["The cat saw the mat"]
         sentence2 = ["The cat sat on the mat"]

--- a/run_vptq.py
+++ b/run_vptq.py
@@ -9,6 +9,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Optional
 
+from sentence_transformers import SentenceTransformer
 import torch
 from torch.multiprocessing import set_start_method
 from transformers import AutoTokenizer, HfArgumentParser, set_seed
@@ -16,6 +17,7 @@ from transformers import AutoTokenizer, HfArgumentParser, set_seed
 from vptq.models.llama import eval_llama, get_llama, quant_llama
 from vptq.models.mistral import get_mistral
 from vptq.models.qwen import eval_qwen, get_qwen, quant_qwen
+from vptq.models.nvembed import get_nvembed, quant_nvembed
 from vptq.quantizer import QuantizationArguments
 from vptq.utils.data import get_data_loader
 from vptq.utils.pack import pack_model
@@ -23,12 +25,12 @@ from vptq.utils.pack import pack_model
 
 @dataclass
 class VPTQArguments:
-    model_name: str = field(default='meta-llama/Llama-2-7b-hf')
+    model_name: str = field(default="meta-llama/Llama-2-7b-hf")
     seq_len: Optional[int] = field(default=None)
     quant_step: int = field(default=1)
     percdamp: float = field(default=0.01)
     blocksize: int = field(default=128)
-    output_dir: str = field(default='outputs')
+    output_dir: str = field(default="outputs")
     seed: int = field(default=0)
     eval: bool = field(default=False)
     new_eval: bool = field(default=False)
@@ -49,69 +51,89 @@ if __name__ == "__main__":
     # set output folder based on time
     args.output_dir = osp.join(args.output_dir, time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime()))
 
-    set_start_method('spawn')
+    set_start_method("spawn")
 
     set_seed(args.seed)
 
-    if 'llama' in args.model_name.lower():
+    if "llama" in args.model_name.lower():
         model = get_llama(args.model_name)
-    elif 'qwen' in args.model_name.lower():
+    elif "qwen" in args.model_name.lower():
         model = get_qwen(args.model_name)
-    elif 'mistral' in args.model_name.lower():
+    elif "mistral" in args.model_name.lower():
         model = get_mistral(args.model_name)
+    elif "nv-embed" in args.model_name.lower():
+        model = get_nvembed(args.model_name)
     else:
-        raise ValueError(f'Unsupported model: {args.model_name}')
+        raise ValueError(f"Unsupported model: {args.model_name}")
 
     # set sequence length
     if args.seq_len or model.seqlen is None:
         model.seqlen = args.seq_len
-    print(f'model sequence length: {model.seqlen}')
+    print(f"model sequence length: {model.seqlen}")
 
     model.eval()
 
     tick = time.time()
     print(f'exp time: {time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())}')
-    print(f'args: {args}')
-    print(f'quant_args: {quant_args}')
+    print(f"args: {args}")
+    print(f"quant_args: {quant_args}")
 
-    if 'llama' in args.model_name.lower() or \
-            'mistral' in args.model_name.lower():
+    if "llama" in args.model_name.lower() or "mistral" in args.model_name.lower():
         model, quantizers = quant_llama(model, args, quant_args)
-    elif 'qwen' in args.model_name.lower():
+    elif "qwen" in args.model_name.lower():
         model, quantizers = quant_qwen(model, args, quant_args)
+    elif "nv-embed" in args.model_name.lower():
+        model, quantizers = quant_nvembed(model, args, quant_args)
     else:
-        raise ValueError(f'Unsupported model: {args.model_name}')
+        raise ValueError(f"Unsupported model: {args.model_name}")
 
     # save model, not for inference
     if args.save_model:
-        model_path = osp.join(args.output_dir, 'model/')
+        model_path = osp.join(args.output_dir, "model/")
         model.save_pretrained(model_path)
-        print(f'save model to {model_path}')
-        tokenizer = AutoTokenizer.from_pretrained(f'{args.model_name}', legacy=False)
+        print(f"save model to {model_path}")
+        tokenizer = AutoTokenizer.from_pretrained(f"{args.model_name}", legacy=False)
         tokenizer.save_pretrained(model_path)
-        print(f'save tokenizer to {model_path}')
+        print(f"save tokenizer to {model_path}")
 
     # save packed model for inference
     if args.save_packed_model:
-        model_path = osp.join(args.output_dir, 'packed_model/')
+        model_path = osp.join(args.output_dir, "packed_model/")
         model = pack_model(model, from_type=torch.uint16, to_type=torch.uint16, as_type=torch.int16)
         model.save_pretrained(model_path, safe_serialization=False)
-        print(f'save packed model to {model_path}')
-        tokenizer = AutoTokenizer.from_pretrained(f'{args.model_name}', legacy=False)
+        print(f"save packed model to {model_path}")
+        tokenizer = AutoTokenizer.from_pretrained(f"{args.model_name}", legacy=False)
 
         tokenizer.save_pretrained(model_path)
-        print(f'save tokenizer to {model_path}')
+        print(f"save tokenizer to {model_path}")
 
         # reload packed model to evaluate
         import vptq
-        model = vptq.AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
-        print(f'load packed model from {model_path}')
+
+        if isinstance(model, SentenceTransformer):
+            model = vptq.AutoModelForST.from_pretrained(model_path)
+        else:
+            model = vptq.AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
+
+        print(f"load packed model from {model_path}")
 
     model.eval()
+
+    if isinstance(model, SentenceTransformer):
+        sentence1 = ["The cat saw the mat"]
+        sentence2 = ["The cat sat on the mat"]
+
+        embeddings1 = model.encode(sentence1, convert_to_tensor=True)
+        embeddings2 = model.encode(sentence2, convert_to_tensor=True)
+
+        cosine_scores = torch.nn.functional.cosine_similarity(embeddings1, embeddings2)
+        print(f"cosine similarity: {cosine_scores.item()}")
+        exit()
+
     if args.eval:
-        datasets = ['wikitext2', 'c4']
+        datasets = ["wikitext2", "c4"]
     if args.new_eval:
-        datasets = ['wikitext2', 'c4-new']
+        datasets = ["wikitext2", "c4-new"]
 
     seqlens = [2048, 4096, 8192]
 
@@ -125,17 +147,16 @@ if __name__ == "__main__":
                 dataset, seed=args.seed, model=args.model_name, seqlen=model.seqlen
             )
             print(dataset)
-            if 'llama' in args.model_name.lower() \
-                    or 'mistral' in args.model_name.lower():
-                ppl = eval_llama(model, testloader, 'cuda')
-            elif 'qwen' in args.model_name.lower():
-                ppl = eval_qwen(model, testloader, 'cuda')
+            if "llama" in args.model_name.lower() or "mistral" in args.model_name.lower():
+                ppl = eval_llama(model, testloader, "cuda")
+            elif "qwen" in args.model_name.lower():
+                ppl = eval_qwen(model, testloader, "cuda")
             else:
-                raise ValueError(f'Unsupported model: {args.model_name}')
+                raise ValueError(f"Unsupported model: {args.model_name}")
 
-            if f'ctx_{seqlen}' not in results:
-                results[f'ctx_{seqlen}'] = {}
-            results[f'ctx_{seqlen}'][dataset] = ppl
+            if f"ctx_{seqlen}" not in results:
+                results[f"ctx_{seqlen}"] = {}
+            results[f"ctx_{seqlen}"][dataset] = ppl
 
-        with open(osp.join(args.output_dir, 'ppl_results.json'), "w") as f:
+        with open(osp.join(args.output_dir, "ppl_results.json"), "w") as f:
             json.dump(results, f, indent=2)

--- a/run_vptq.py
+++ b/run_vptq.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     args, quant_args = parser.parse_args_into_dataclasses()
 
     # set output folder based on time
-    args.output_dir = osp.join(args.output_dir, time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime()))
+    args.output_dir = osp.join(args.output_dir, time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime()))
 
     set_start_method("spawn")
 
@@ -111,7 +111,7 @@ if __name__ == "__main__":
         import vptq
 
         if isinstance(model, SentenceTransformer):
-            model = vptq.AutoModelForST.from_pretrained(model_path)
+            model = vptq.AutoModelForSentenceEmbeddings.from_pretrained(model_path)
         else:
             model = vptq.AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
 

--- a/run_vptq.py
+++ b/run_vptq.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
         import vptq
 
         if isinstance(model, SentenceTransformer):
-            model = vptq.AutoModelForSentenceEmbeddings.from_pretrained(model_path)
+            model = vptq.AutoModelForSentenceEmbeddings.from_pretrained(model_path, device_map="auto")
         else:
             model = vptq.AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
 

--- a/vptq/__init__.py
+++ b/vptq/__init__.py
@@ -5,3 +5,4 @@
 
 __version__ = "0.0.3"
 from vptq.layers import AutoModelForCausalLM as AutoModelForCausalLM
+from vptq.layers import AutoModelForST as AutoModelForST

--- a/vptq/__init__.py
+++ b/vptq/__init__.py
@@ -5,4 +5,4 @@
 
 __version__ = "0.0.3"
 from vptq.layers import AutoModelForCausalLM as AutoModelForCausalLM
-from vptq.layers import AutoModelForST as AutoModelForST
+from vptq.layers import AutoModelForSentenceEmbeddings as AutoModelForSentenceEmbeddings

--- a/vptq/layers/__init__.py
+++ b/vptq/layers/__init__.py
@@ -4,4 +4,4 @@
 # --------------------------------------------------------------------------
 
 from vptq.layers.model_base import AutoModelForCausalLM as AutoModelForCausalLM
-from vptq.layers.model_base import AutoModelForST as AutoModelForST
+from vptq.layers.model_base import AutoModelForSentenceEmbeddings as AutoModelForSentenceEmbeddings

--- a/vptq/layers/__init__.py
+++ b/vptq/layers/__init__.py
@@ -4,3 +4,4 @@
 # --------------------------------------------------------------------------
 
 from vptq.layers.model_base import AutoModelForCausalLM as AutoModelForCausalLM
+from vptq.layers.model_base import AutoModelForST as AutoModelForST

--- a/vptq/layers/model_base.py
+++ b/vptq/layers/model_base.py
@@ -221,7 +221,7 @@ class AutoModelForCausalLM(transformers.AutoModel):
         return model
 
 
-class AutoModelForST(SentenceTransformer):
+class AutoModelForSentenceEmbeddings(SentenceTransformer):
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
         model_kwargs = {

--- a/vptq/layers/model_base.py
+++ b/vptq/layers/model_base.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import accelerate
 import huggingface_hub
 import safetensors
+from sentence_transformers import SentenceTransformer
 import torch
 import transformers
 from tqdm import tqdm
@@ -104,15 +105,16 @@ def attach_execution_device_hook(
         )
 
 
-class AutoModelForCausalLM(transformers.AutoModelForCausalLM):
-
+class AutoModelForCausalLM(transformers.AutoModel):
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path, auto_conf=None, *args, **kwargs):
         init_contexts = [
             transformers.modeling_utils.no_init_weights(),
             accelerate.init_empty_weights(),
         ]
-        auto_conf = transformers.AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        if auto_conf is None:
+            auto_conf = transformers.AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
+
         cls_kwargs = {}
         torch_dtype = kwargs.get("dtype", auto_conf.torch_dtype)
         cls_kwargs["torch_dtype"] = torch_dtype
@@ -120,7 +122,10 @@ class AutoModelForCausalLM(transformers.AutoModelForCausalLM):
             model = cls.from_config(auto_conf, *args, **cls_kwargs)
 
         target_layer = VQuantLinear
-        quant_config = auto_conf.quant_config
+        if hasattr(auto_conf, "text_config"):
+            quant_config = auto_conf.text_config.quant_config
+        else:
+            quant_config = auto_conf.quant_config
 
         # replace linear layers with quantized linear layers
         with transformers.utils.generic.ContextManagers([accelerate.init_empty_weights()]):
@@ -212,5 +217,30 @@ class AutoModelForCausalLM(transformers.AutoModelForCausalLM):
         # logger.warning(f"Missing keys: {all_missing_keys[:5]}..., Unexpected keys: {all_unexpected_keys[:5]}...")
         model.eval()
 
+        torch.cuda.empty_cache()
+        return model
+
+
+class AutoModelForST(SentenceTransformer):
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        model_kwargs = {
+            "torch_dtype": torch.bfloat16,
+        }
+        model = SentenceTransformer(
+            pretrained_model_name_or_path,
+            model_kwargs=model_kwargs,
+            trust_remote_code=True,
+        )
+        print(model._modules["0"])
+        text_config = model._modules["0"]._modules["auto_model"].config
+        model._modules["0"]._modules["auto_model"].embedding_model = None
+        torch.cuda.empty_cache()
+
+        model._modules["0"]._modules["auto_model"] = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path, auto_conf=text_config, *args, **kwargs
+        )
+
+        model.eval()
         torch.cuda.empty_cache()
         return model

--- a/vptq/layers/model_base.py
+++ b/vptq/layers/model_base.py
@@ -158,7 +158,7 @@ class AutoModelForCausalLM(transformers.AutoModel):
         if Path(pretrained_model_name_or_path).exists():
             checkpoint = pretrained_model_name_or_path
         else:  # remote
-            token_arg = {"token": kwargs.get("token", None)}
+            token_arg = {"token": kwargs.get("token")}
             checkpoint = huggingface_hub.snapshot_download(
                 repo_id=pretrained_model_name_or_path, ignore_patterns=["*.bin"], **token_arg
             )
@@ -190,15 +190,15 @@ class AutoModelForCausalLM(transformers.AutoModel):
             max_memory=max_memory,
             no_split_module_classes=no_split_module_classes[0],
             dtype=torch_dtype,
-            preload_module_classes=["VQuantLinear"]
+            preload_module_classes=["VQuantLinear"],
         )
 
         # check cuda kernel exist
         if importlib.util.find_spec("vptq.ops") is not None:
             pass
         else:
-            print('!!! Warning !!!: CUDA kernel not found, please check CUDA and VPTQ installation.')
-            print('!!! Warning !!!: Running on Torch Implementation, which is extremely slow.')
+            print("!!! Warning !!!: CUDA kernel not found, please check CUDA and VPTQ installation.")
+            print("!!! Warning !!!: Running on Torch Implementation, which is extremely slow.")
 
         # weight_bins = glob.glob(str(Path(pretrained_model_name_or_path).absolute() / '*.safetensors'))
         # all_missing_keys = []

--- a/vptq/models/nvembed.py
+++ b/vptq/models/nvembed.py
@@ -1,0 +1,233 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+# Model from https://github.com/Cornell-RelaxML/quip-sharp/blob/main/model/llama.py
+
+import os
+import time
+import torch
+import torch.multiprocessing as mp
+from sentence_transformers import SentenceTransformer
+from vptq.quantize_executer import quantize_executer
+from vptq.layers.vqlinear import VQuantLinear
+from vptq.utils.layer_utils import find_layers, replace_layer
+
+
+def get_nvembed(model_name, seqlen=None):
+    def skip(*args, **kwargs):
+        pass
+
+    torch.nn.init.kaiming_uniform_ = skip
+    torch.nn.init.uniform_ = skip
+    torch.nn.init.normal_ = skip
+
+    model_kwargs = {
+        "torch_dtype": torch.bfloat16,
+    }
+    model = SentenceTransformer(
+        model_name,
+        model_kwargs=model_kwargs,
+        trust_remote_code=True,
+    )
+
+    model.max_seq_length = seqlen
+    return model
+
+
+def quant_nvembed(model: SentenceTransformer, args, quant_args, dev="cuda"):
+    # model.model.required_grad = False
+    print("Starting VPTQ...")
+
+    model = model._modules["0"]._modules["auto_model"]
+
+    use_cache = model.config.text_config.use_cache
+    model.config.text_config.use_cache = False
+    # get decoder layers
+    layers = model.embedding_model.layers
+
+    model.embedding_model.embed_tokens = model.embedding_model.embed_tokens.to(dev)
+    if hasattr(model.embedding_model, "rotary_emb"):
+        model.embedding_model.rotary_emb = model.embedding_model.rotary_emb.to(dev)
+    model.embedding_model.norm = model.embedding_model.norm.to(dev)
+    layers[0] = layers[0].to(dev)
+
+    dtype = next(iter(model.parameters())).dtype
+    print(f"model dtype: {dtype}")
+
+    # save model to cpu
+    model = model.cpu()
+
+    layers[0] = layers[0].cpu()
+
+    model.embedding_model.embed_tokens = model.embedding_model.embed_tokens.cpu()
+    model.embedding_model.norm = model.embedding_model.norm.cpu()
+    model.config.text_config.use_cache = use_cache
+
+    torch.cuda.empty_cache()
+
+    model.embedding_model.embed_tokens = model.embedding_model.embed_tokens.to("cpu")
+    # fix for llama-3.1
+    if hasattr(model.embedding_model, "rotary_emb"):
+        model.embedding_model.rotary_emb = model.embedding_model.rotary_emb.to("cpu")
+    model.embedding_model.norm = model.embedding_model.norm.to("cpu")
+    layers[0] = layers[0].to("cpu")
+    model = model.cpu()
+
+    # multiple gpus VPTQ
+    quantizers = {}
+    layers = model.embedding_model.layers
+
+    print(f'----quantization start ...---- {time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())}')
+
+    # calculate task allocation
+    total_layers = len(layers)
+    num_gpus = min(args.num_gpus, total_layers)
+
+    base_layers_per_gpu = total_layers // num_gpus
+    remaining_layers = total_layers % num_gpus
+
+    tasks = []
+    current_layer_idx = 0
+
+    # Distribute tasks to GPUs
+    for gpu_idx in range(num_gpus):
+        current_gpu_tasks = []
+
+        # Calculate how many layers this GPU should handle
+        layers_for_this_gpu = base_layers_per_gpu
+        if gpu_idx < remaining_layers:
+            layers_for_this_gpu += 1
+
+        # Assign layers to this GPU
+        for _ in range(layers_for_this_gpu):
+            current_gpu_tasks.append((current_layer_idx, layers[current_layer_idx]))
+            current_layer_idx += 1
+
+        tasks.append(current_gpu_tasks)
+
+    # print task allocation
+    for gpu_idx in range(len(tasks)):
+        task = [layer_idx for layer_idx, _ in tasks[gpu_idx]]
+        print(f"gpu {gpu_idx} tasks: {task}")
+
+    # init multiprocessing
+    processes = []
+    mq_manager = mp.get_context("spawn").Manager()
+    input_queues = mq_manager.Queue()
+    output_queues = mq_manager.Queue()
+
+    if args.num_gpus == 1:
+        layer_state_dicts, layer_qlinear_args = quantize_executer(0, tasks[0], args, quant_args, None, None)
+    else:
+        for gpu_idx in range(args.num_gpus):
+            # we have to set CUDA_VISIBLE_DEVICES here
+            # oscuml only supports to run on GPU:0
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_idx)
+            p = mp.Process(
+                target=quantize_executer,
+                args=(
+                    gpu_idx,
+                    tasks[gpu_idx],
+                    args,
+                    quant_args,
+                    input_queues,
+                    output_queues,
+                ),
+            )
+
+            p.start()
+            processes.append(p)
+
+        for p in processes:
+            p.join()
+
+    print(f'----quantization done ...---- {time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())}')
+
+    # init quantized model
+    model_name = model.embedding_model.config._name_or_path
+    # qmodel = init_quantized_llama(model_name, args, quant_args).cpu()
+
+    if True:
+        layer_state_dicts = {}
+        layer_qlinear_args = {}
+
+        # load save qlinear from files to avoid memory overflow
+        if args.save_qlinear:
+            for layer_idx in range(len(layers)):
+                # load to cpu
+                layer_state_dicts[layer_idx] = torch.load(
+                    f"{args.output_dir}/qlinear_layer_state_{layer_idx}.pt", map_location="cpu"
+                )
+                # bypass KeyError: torch.uint16
+                for key, value in layer_state_dicts[layer_idx].items():
+                    if "indices" in key:
+                        layer_state_dicts[layer_idx][key] = value.view(torch.uint16)
+                layer_qlinear_args[layer_idx] = torch.load(
+                    f"{args.output_dir}/qlinear_args_{layer_idx}.pt", map_location="cpu"
+                )
+        else:
+            while not output_queues.empty():
+                (gpu_id, layer_idx, _layer_state_dict, _layer_qlinear_args) = output_queues.get()
+                layer_state_dicts[layer_idx] = _layer_state_dict
+                layer_qlinear_args[layer_idx] = _layer_qlinear_args
+                print(f"gpu {gpu_id} layer {layer_idx} quantized")
+
+    # check if all layers are quantized
+    if len(layer_state_dicts) != len(layers):
+        print("Error: not all layers are quantized")
+        exit(1)
+
+    qmodel = get_quantized_nvembed(model_name, args.seq_len, layer_state_dicts, layer_qlinear_args)
+
+    model = qmodel
+
+    print(f"qmodel: {model}")
+
+    torch.cuda.empty_cache()
+    return model, quantizers
+
+
+def get_quantized_nvembed(model_name, seqlen, layer_state_dicts, layer_qlinear_args):
+    # print(f'layer_state_dicts: {layer_state_dicts.keys()}')
+    st_model = get_nvembed(model_name, seqlen=seqlen)
+    model = st_model._modules["0"]._modules["auto_model"]
+
+    dtype = next(iter(model.parameters())).dtype
+    layers: list[torch.nn.Module] = model.embedding_model.layers
+
+    for layer_idx, layer_state_dict in layer_state_dicts.items():
+        # print(f'load quantized layer {layer_idx}')
+        # print(f'layer_state_dict: {layer_state_dict.keys()}')
+        layer = layers[layer_idx]
+        ops = find_layers(layer)
+
+        for name, op in ops.items():
+            # init qlinear
+            qlayer = VQuantLinear(
+                **layer_qlinear_args[layer_idx][name],
+                dtype=dtype,
+            )
+            module_name = name.split(".")[-1]
+            replace_layer(layer, module_name, qlayer)
+
+        # convert dtype
+        # print(f'default dtype: {dtype}')
+        for param_name, param in layer_state_dict.items():
+            if layer_state_dict[param_name].dtype not in [
+                dtype,
+                torch.int64,
+                torch.int32,
+                torch.int16,
+                torch.int8,
+                torch.uint64,
+                torch.uint32,
+                torch.uint16,
+                torch.uint8,
+                torch.bool,
+            ]:
+                layer_state_dict[param_name] = layer_state_dict[param_name].to(dtype)
+
+        layers[layer_idx].load_state_dict(layer_state_dict)
+
+    return st_model

--- a/vptq/utils/pack.py
+++ b/vptq/utils/pack.py
@@ -4,16 +4,12 @@
 # --------------------------------------------------------------------------
 
 # import time
-import glob
 import math
-import os.path as osp
-from argparse import ArgumentParser
 from typing import Dict
 
+from sentence_transformers.SentenceTransformer import SentenceTransformer
 import torch
-from safetensors import safe_open
 
-from vptq.utils.config import Config
 
 # from vptq.models.config import Config
 # from vptq.models.llama import llama_eval
@@ -30,17 +26,17 @@ def pack_index(
     res_indice: torch.Tensor = None,
     res_bits: int = 0,
     index_dtype: torch.dtype = torch.uint16,
-    as_dtype: torch.dtype = torch.int32
+    as_dtype: torch.dtype = torch.int32,
 ) -> torch.Tensor:
-
     total_bits = index_bits + res_bits
     assert total_bits <= 32, f"total index bits {total_bits} should be less than 32"
-    assert as_dtype in [torch.int32], f"as_dtype should be int32"
+    assert as_dtype in [torch.int32], "as_dtype should be int32"
 
     # upcast the indice to uint64 to avoid overflow on signed bit
     if res_indice is not None:
-        merged_indice = ((res_indice.view(index_dtype).to(torch.uint64).view(torch.int64) << index_bits) |
-                         indice.view(index_dtype).to(torch.uint64).view(torch.int64))
+        merged_indice = (res_indice.view(index_dtype).to(torch.uint64).view(torch.int64) << index_bits) | indice.view(
+            index_dtype
+        ).to(torch.uint64).view(torch.int64)
     else:
         merged_indice = indice.view(index_dtype).to(torch.uint64).view(torch.int64)
 
@@ -54,7 +50,7 @@ def pack_index(
         out,
         (0, paded_bits),
         value=0,
-        mode='constant',
+        mode="constant",
     ).reshape(*merged_indice.shape[:-1], -1, 32)
     wf1 = torch.arange(0, 32, 1).to(merged_indice.device).view(1, 1, 1, -1)
     out = torch.bitwise_left_shift(out, wf1)
@@ -67,7 +63,7 @@ def pack_index(
         res_bits,
         res_indice.shape[-1] if res_indice is not None else 0,
         index_dtype=index_dtype,
-        as_dtype=as_dtype
+        as_dtype=as_dtype,
     )
     assert torch.allclose(
         indice.view(index_dtype).to(torch.int64),
@@ -83,7 +79,7 @@ def pack_index(
             res_bits,
             res_indice.shape[-1] if res_indice is not None else 0,
             index_dtype=index_dtype,
-            as_dtype=as_dtype
+            as_dtype=as_dtype,
         )[0],
     )
     if res_indice is not None:
@@ -96,7 +92,7 @@ def pack_index(
                 res_bits,
                 res_indice.shape[-1] if res_indice is not None else 0,
                 index_dtype=index_dtype,
-                as_dtype=as_dtype
+                as_dtype=as_dtype,
             )[1],
         )
     return out
@@ -109,9 +105,8 @@ def unpack_index_tensor(
     res_bits: int = 0,
     num_res_elements: int = 0,
     index_dtype: torch.dtype = torch.uint16,
-    as_dtype: torch.dtype = torch.int32
+    as_dtype: torch.dtype = torch.int32,
 ) -> torch.Tensor:
-
     total_bits = index_bits + res_bits
     wf = torch.arange(0, 32, 1).to(pack_tensor.device).view(1, 1, 1, -1)
     out = torch.bitwise_right_shift(torch.unsqueeze(pack_tensor, -1), wf)
@@ -144,13 +139,12 @@ def dtype_convert(data, from_dtype, to_dtype, as_type):
 
 
 def convert_idx_dtype(model, from_dtype, to_dtype, as_type):
-    print(f"converting model indices from {from_dtype} "
-          f"to {to_dtype} as {as_type}")
+    print(f"converting model indices from {from_dtype} " f"to {to_dtype} as {as_type}")
 
     quant_config = {}
     for mod_name, sub_mod in model.named_modules():
         # print(f'mod_name: {mod_name}, sub_mod: {sub_mod}')
-        if 'VQuantLinear' in str(type(sub_mod)):
+        if "VQuantLinear" in str(type(sub_mod)):
             sub_mod.cuda()
             # print(
             #     f'---debug---'
@@ -164,8 +158,7 @@ def convert_idx_dtype(model, from_dtype, to_dtype, as_type):
             else:
                 sub_mod.indices.data = dtype_convert(sub_mod.indices.data, from_dtype, to_dtype, as_type)
 
-            if hasattr(sub_mod, "res_indices") and \
-                    sub_mod.res_indices is not None:
+            if hasattr(sub_mod, "res_indices") and sub_mod.res_indices is not None:
                 if sub_mod.res_indices.dtype == torch.int64:
                     sub_mod.res_indices.data = dtype_convert(
                         sub_mod.res_indices.data, sub_mod.res_indices.data.dtype, to_dtype, as_type
@@ -173,8 +166,7 @@ def convert_idx_dtype(model, from_dtype, to_dtype, as_type):
                 else:
                     sub_mod.res_indices.data = dtype_convert(sub_mod.res_indices.data, from_dtype, to_dtype, as_type)
 
-            if hasattr(sub_mod, "outlier_indices") and \
-                    sub_mod.outlier_indices is not None:
+            if hasattr(sub_mod, "outlier_indices") and sub_mod.outlier_indices is not None:
                 if sub_mod.outlier_indices.dtype == torch.int64:
                     sub_mod.outlier_indices.data = dtype_convert(
                         sub_mod.outlier_indices.data, sub_mod.outlier_indices.data.dtype, to_dtype, as_type
@@ -194,7 +186,7 @@ def convert_idx_dtype(model, from_dtype, to_dtype, as_type):
                 index_bits=int(math.log2(sub_mod.num_centroids)),
                 res_indice=sub_mod.res_indices,
                 res_bits=int(math.log2(sub_mod.num_res_centroids)) if sub_mod.res_indices is not None else 0,
-                index_dtype=to_dtype
+                index_dtype=to_dtype,
             ).data
 
             sub_mod.res_indices = None
@@ -204,27 +196,45 @@ def convert_idx_dtype(model, from_dtype, to_dtype, as_type):
             # assert (sub_mod.fast_dequant() - sub_mod.dequant()).max().item() < 0.001
             sub_mod.cpu()
             quant_config[mod_name] = sub_mod.init_args
-            quant_config[mod_name]['is_indice_packed'] = True
+            quant_config[mod_name]["is_indice_packed"] = True
 
-    model.config.quant_config = quant_config
+    if hasattr(model.config, "text_config"):
+        model.config.text_config.quant_config = quant_config
+    else:
+        model.config.quant_config = quant_config
     return model
 
 
 # # workaround for the issue that the bias field in the config is not updated correctly
 def fix_tensor_in_config(model):
-    config_dict = model.config.to_dict()
-    quant_config = config_dict['quant_config']
+    config = model.config
+    if hasattr(config, "text_config"):
+        config = config.text_config
+    config_dict = config.to_dict()
+    quant_config = config_dict["quant_config"]
     for layer_name, layer_config in quant_config.items():
-        if isinstance(layer_config, Dict) and 'bias' in layer_config.keys():
-            if isinstance(layer_config['bias'], torch.Tensor):
+        if isinstance(layer_config, Dict) and "bias" in layer_config.keys():
+            if isinstance(layer_config["bias"], torch.Tensor):
                 # print(f'Layer {layer_name} has a bias tensor')
-                quant_config[layer_name]['bias'] = True  # Update bias to True
-    config_dict['quant_config'] = quant_config
-    model.config.update(config_dict)
+                quant_config[layer_name]["bias"] = True  # Update bias to True
+    config_dict["quant_config"] = quant_config
+    if hasattr(model.config, "text_config"):
+        model.config.text_config.update(config_dict)
+    else:
+        model.config.update(config_dict)
     return model
 
 
 def pack_model(qmodel, from_type, to_type, as_type):
+    if isinstance(qmodel, SentenceTransformer):
+        st_model = qmodel
+
+        qmodel = qmodel._modules["0"]._modules["auto_model"]
+        model = convert_idx_dtype(qmodel, from_type, to_type, as_type)
+        model = fix_tensor_in_config(model)
+        st_model._modules["0"]._modules["auto_model"] = model
+
+        return st_model
     model = convert_idx_dtype(qmodel, from_type, to_type, as_type)
     model = fix_tensor_in_config(model)
     return model


### PR DESCRIPTION
Add support for quantizing the NV-Embed model using VPTQ. Benchmarked using MTEB to evaluate performance against the `bfloat16` version. Current benchmarks are based on a single task, further testing with more meaningful retrieval tasks and parameter tuning would be interesting to explore.

Benchmarks below are provided for context only and are not part of this PR.

Batch sizes were set to `16` for `VPTQ-NVEmbed` and `4` for `bfloat16`, as these were the maximum sizes that fit on a 24GB GPU.

#### Results on a specific task in (MTEB)

| Model                 | Main Score | Evaluation Time (s) |
|-----------------------|------------|-----------------------|
| VPTQ-NVEmbed-128-1024 | 0.33361    | 753.76               |
| NV-Embed bfloat16     | 0.38469    | 874.00               |
