### PR TITLE
fix(setup.py): include all Python files in package built

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,6 +295,10 @@ setup(
         "build_ext": CMakeBuildExt,
         "clean": Clean,
         "develop": Develop,
-        "pytest": PyTest,
+        "tests": PyTest,
     },
+    package_data={
+        "vptq": ["**/*.py"],
+    },
+    include_package_data=True,
 )


### PR DESCRIPTION
- Use recursive pattern `**/*.py` to include all Python files in subdirectories

This change ensures that all Python source files from subdirectories (layers, ops, tools, utils) are properly included in the built wheel package.